### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -12,7 +12,7 @@ jobs:
             - uses: actions/checkout@master
 
             - name: Build and publish
-              uses: elgohr/Publish-Docker-Github-Action@master
+              uses: elgohr/Publish-Docker-Github-Action@v5
               with:
                   name: citipo/docker-google-fonts-proxy/alpine
                   username: citipo


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore